### PR TITLE
fix: 修复英文环境下自动安装脚本时按钮文本无法识别

### DIFF
--- a/packages/app/src/worker/index.ts
+++ b/packages/app/src/worker/index.ts
@@ -405,7 +405,7 @@ async function initScripts(urls: string[], browser: BrowserContext, config?: Bro
 					if (config?.force_update_script) {
 						btn?.click();
 					} else {
-						if (['更新', '安装', '添加'].some((text) => (btn?.textContent || '').trim() === text)) {
+						if (['更新', '安装', '添加', 'Update', 'Install', 'Add'].some((text) => (btn?.textContent || '').trim() === text)) {
 							btn?.click();
 						} else {
 							return false;


### PR DESCRIPTION
我系统是英文然后这个界面的安装一直自动不成功啊😂，补一下英文关键词
![Image](https://github.com/user-attachments/assets/4a5f9864-0461-4566-8cb7-8f9c1d9a32e3)