### PR TITLE
chore(ci):放弃了对winarm64的支持，升级构建环境至 Node.js 22.14 并优化Github Action的工作流

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "*"
+  workflow_dispatch:
 
 jobs:
   release_to_tencent_cloud:
@@ -14,9 +15,9 @@ jobs:
           - os: windows-latest
             platform: win
             arch: x64
-          - os: windows-11-arm
-            platform: win
-            arch: arm64
+          # - os: windows-11-arm
+          #   platform: win
+          #   arch: arm64
             
           # macOS 构建
           - os: macos-13
@@ -40,15 +41,17 @@ jobs:
       - name: Check out Git repository
         uses: actions/checkout@v5
 
-      - name: Install Node.js, NPM and Yarn
+      - name: Install Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: "24"
-          
+          # electron的不同版本有专门对应的node版本，当前项目electron35对应的是22.14
+          node-version: "22.14"
+      
+      # 在GitHub Action当中应该使用uses: pnpm/action-setup而不是npm install pnpm
       - name: Npm Install
-        run: |
-          npm i pnpm -g &&
-          pnpm install
+        uses: pnpm/action-setup@v4
+        with:
+          run_install: true
 
       - name: Build Change Logs
         run: npm run changelog:current

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
 	"name": "ocs-desktop",
 	"version": "2.9.28",
 	"description": "desktop for userscript",
+	"packageManager": "pnpm@10.21.0",
 	"files": [
 		"lib",
 		"dist"


### PR DESCRIPTION
### chore(package): 添加pnpm包管理器版本信息
- 在package.json中添加了packageManager字段
- 指定包管理器版本为pnpm@10.21.0

### ci(build): 优化GitHub Actions构建流程
- 保留了原来的tag触发的基础上，添加 workflow_dispatch 触发事件支持手动触发工作流
- 注释掉 Windows ARM 构建配置，暂时禁用该平台构建
- 更新 Node.js 版本为 22.14，匹配 Electron 35 版本需求#63，具体参考[Electron Releases](https://www.electronjs.org/docs/latest/tutorial/electron-timelines)
- 使用 pnpm/action-setup 代替安装 pnpm，符合Github Action的工作习惯
- 规范构建步骤命名，提升构建脚本可读性和维护性