### PR TITLE
001 fix GitHub release upload

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -123,7 +123,7 @@ jobs:
 
       - name: Upload Release
         uses: softprops/action-gh-release@v2
-        if: startsWith(github.ref, 'refs/tags/') && runner.os == 'Linux' && matrix.arch == 'x64'
+        if: startsWith(github.ref, 'refs/tags/')
         with:
           body_path: "./release.txt"
           files: "./packages/app/dist/**.exe,./packages/app/dist/**.dmg,./packages/app/dist/**.AppImage,./packages/app/dist/**.zip,./packages/app/dist/**.deb,./packages/app/dist/**.rpm"

--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,8 @@ dist/
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+
+# Claude Code and specify framework
+.claude/
+.specify/
+CLAUDE.md


### PR DESCRIPTION
Changes:                                                                                                                                                                                               
  - Removed platform restriction from "Upload Release" step in .github/workflows/build.yml                                                                                                               
  - Now ALL platform builds (Windows, macOS, Linux) will upload their artifacts to GitHub Releases                                                                                                       
  - Previously only Linux x64 uploaded artifacts, preventing users from downloading Windows/macOS installers                                                                                             
                                                                                                                                                                                                         
  Commit: 0b9f457