### PR TITLE
fix(linux): 修复 AppImage 首次初始化重启与浏览器检测链路

### DIFF
--- a/packages/app/index.ts
+++ b/packages/app/index.ts
@@ -50,17 +50,24 @@ function bootstrap() {
 
 				await app.whenReady();
 				const window = createWindow();
-				await task('初始化谷歌浏览器', () => initChrome(window));
+				const relaunched = await task('初始化谷歌浏览器', () => initChrome(window));
+				if (relaunched) {
+					return;
+				}
 
 				app.on('quit', (e) => {
 					e.preventDefault();
 					// 交给渲染层去关闭浏览器
-					window.webContents.send('close');
+					if (!window.isDestroyed() && !window.webContents.isDestroyed()) {
+						window.webContents.send('close');
+					}
 				});
 
 				window.on('close', (e) => {
 					e.preventDefault();
-					window.webContents.send('close');
+					if (!window.isDestroyed() && !window.webContents.isDestroyed()) {
+						window.webContents.send('close');
+					}
 				});
 
 				window.webContents.once('did-finish-load', () => {

--- a/packages/app/src/tasks/init.chrome.ts
+++ b/packages/app/src/tasks/init.chrome.ts
@@ -5,16 +5,20 @@ import { sleep, unzip } from '../utils';
 import { Logger } from '../logger';
 import { glob } from 'glob';
 import child_process from 'child_process';
+import { store } from '../store';
+
 const logger = Logger('chrome-init');
 
-export async function initChrome(win: BrowserWindow) {
+export async function initChrome(win: BrowserWindow): Promise<boolean> {
 	try {
-		// 解压浏览器内核
-		const chromePath = path.join(process.resourcesPath, 'bin', 'chrome');
-		logger.log('chromePath', chromePath);
-		if (!fs.existsSync(chromePath)) {
-			logger.error(`内置浏览器目录不存在: ${chromePath}`);
-			return;
+		const chromeResourcePath = path.join(process.resourcesPath, 'bin', 'chrome');
+		const chromeRuntimePath = path.join(app.getPath('userData'), 'bin', 'chrome');
+		const chromeZipPath = path.join(chromeResourcePath, 'chrome.zip');
+		const chromeTempPath = path.join(chromeRuntimePath, 'chrome_temp');
+
+		if (!fs.existsSync(chromeZipPath)) {
+			logger.error(`内置浏览器压缩包不存在: ${chromeZipPath}`);
+			return false;
 		}
 
 		const chrome_filename =
@@ -24,10 +28,15 @@ export async function initChrome(win: BrowserWindow) {
 				? 'chrome'
 				: 'Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing';
 
-		if (fs.existsSync(path.join(chromePath, 'chrome', chrome_filename))) {
+		const chromeFinalPath = path.join(chromeRuntimePath, 'chrome', chrome_filename);
+		if (fs.existsSync(chromeFinalPath)) {
+			ensureChromeExecutablePermission(chromeFinalPath);
+			migrateLegacyBuiltinBrowserPath(chromeFinalPath);
 			logger.log(`内置浏览器已存在，无需初始化`);
-			return;
+			return false;
 		}
+
+		fs.mkdirSync(chromeRuntimePath, { recursive: true });
 
 		const ab = new AbortController();
 		dialog.showMessageBox(win, {
@@ -39,24 +48,27 @@ export async function initChrome(win: BrowserWindow) {
 		});
 		try {
 			if (process.platform === 'darwin') {
-				child_process.execSync('unzip -o ./chrome.zip -d ./chrome_temp', { cwd: chromePath });
+				child_process.execSync('unzip -o "' + chromeZipPath + '" -d "' + chromeTempPath + '"');
 			} else {
-				await unzip(path.join(chromePath, 'chrome.zip'), path.join(chromePath, 'chrome_temp'));
+				await unzip(chromeZipPath, chromeTempPath);
 			}
 			const searchPattern =
 				process.platform === 'darwin' ? '**/*/' + 'Google Chrome for Testing.app' : '**/*/' + chrome_filename;
 
 			const chrome_file = await glob(searchPattern, {
-				nodir: process.platform !== 'darwin', // macOS 查找目录
+				nodir: process.platform !== 'darwin',
 				absolute: true,
-				cwd: path.join(chromePath, 'chrome_temp')
+				cwd: chromeTempPath
 			});
 			logger.log('chrome_file', chrome_file);
 			if (!chrome_file || chrome_file.length === 0) {
 				throw new Error('浏览器压缩包数据错误');
 			}
-			fs.renameSync(path.dirname(chrome_file[0]), path.join(chromePath, 'chrome'));
-			fs.rmdirSync(path.join(chromePath, 'chrome_temp'), { recursive: true });
+			fs.renameSync(path.dirname(chrome_file[0]), path.join(chromeRuntimePath, 'chrome'));
+			fs.rmSync(chromeTempPath, { recursive: true, force: true });
+
+			ensureChromeExecutablePermission(chromeFinalPath);
+			migrateLegacyBuiltinBrowserPath(chromeFinalPath);
 
 			dialog.showMessageBox(win, {
 				title: app.name,
@@ -65,16 +77,68 @@ export async function initChrome(win: BrowserWindow) {
 				noLink: true
 			});
 			await sleep(1000);
-			app.relaunch();
+			if (process.platform === 'linux' && process.env.APPIMAGE) {
+				app.relaunch({
+					execPath: process.env.APPIMAGE,
+					args: process.argv.slice(1)
+				});
+			} else {
+				app.relaunch();
+			}
 			app.quit();
+			return true;
 		} catch (e) {
 			logger.error('初始化谷歌浏览器失败', e);
 			dialog.showErrorBox('初始化谷歌浏览器失败', String(e));
+			return false;
 		} finally {
 			ab.abort();
 		}
 	} catch (e) {
 		logger.error('初始化谷歌浏览器失败', e);
 		dialog.showErrorBox('初始化谷歌浏览器失败', String(e));
+		return false;
+	}
+}
+
+function ensureChromeExecutablePermission(chromeFinalPath: string) {
+	if (process.platform !== 'linux' && process.platform !== 'darwin') {
+		return;
+	}
+
+	const executablePaths = [chromeFinalPath];
+	if (process.platform === 'linux') {
+		const chromeDir = path.dirname(chromeFinalPath);
+		executablePaths.push(path.join(chromeDir, 'chrome_crashpad_handler'));
+		executablePaths.push(path.join(chromeDir, 'chrome-sandbox'));
+		executablePaths.push(path.join(chromeDir, 'chrome-wrapper'));
+	}
+
+	for (const executablePath of executablePaths) {
+		if (!fs.existsSync(executablePath)) continue;
+		try {
+			fs.chmodSync(executablePath, 0o755);
+		} catch (e) {
+			logger.error('chmod chrome executable failed', { executablePath, error: String(e) });
+		}
+	}
+}
+
+function migrateLegacyBuiltinBrowserPath(chromeFinalPath: string) {
+	try {
+		const render = store.store.render;
+		if (!render || typeof render !== 'object') {
+			return;
+		}
+
+		const currentPath = render?.setting?.launchOptions?.executablePath;
+		const legacyChromeRoot = path.join(process.resourcesPath, 'bin', 'chrome');
+		if (typeof currentPath === 'string' && currentPath.startsWith(legacyChromeRoot) && fs.existsSync(chromeFinalPath)) {
+			render.setting.launchOptions.executablePath = chromeFinalPath;
+			store.set('render', render);
+			logger.log('migrate builtin browser path', { from: currentPath, to: chromeFinalPath });
+		}
+	} catch (e) {
+		logger.error('迁移内置浏览器路径失败', e);
 	}
 }

--- a/packages/app/src/tasks/remote.register.ts
+++ b/packages/app/src/tasks/remote.register.ts
@@ -58,11 +58,18 @@ function registerRemoteEvent(name: string, target: any) {
 					]
 				) => {
 					// logger.info({ event: name + '-call', args });
+					const safeReply = (payload: { data?: any; error?: any }) => {
+						try {
+							if (!event.sender.isDestroyed()) {
+								event.sender.send(respondChannel, payload);
+							}
+						} catch {}
+					};
 					try {
 						const result = await target[property](...args);
-						event.reply(respondChannel, { data: result });
+						safeReply({ data: result });
 					} catch (e) {
-						event.reply(respondChannel, { error: e });
+						safeReply({ error: e });
 					}
 				}
 			)

--- a/packages/app/src/utils/browser.ts
+++ b/packages/app/src/utils/browser.ts
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import path from 'path';
+import child_process from 'child_process';
 /**
  * 获取浏览器主版本号
  * @param executablePath 浏览器可执行文件路径
@@ -43,6 +44,19 @@ export function getBrowserMajorVersion(executablePath: string) {
 	}
 	if (manifest && manifest.split('.').length > 1) {
 		return parseInt(manifest.split('.')[0]);
+	}
+
+	if (process.platform === 'linux') {
+		try {
+			const versionOutput = child_process.execFileSync(executablePath, ['--version'], {
+				encoding: 'utf-8'
+			});
+			const match = versionOutput.match(/(\d+)\./);
+			if (!match) return;
+			const major = parseInt(match[1]);
+			if (isNaN(major)) return;
+			return major;
+		} catch {}
 	}
 }
 

--- a/packages/app/src/worker/index.ts
+++ b/packages/app/src/worker/index.ts
@@ -376,8 +376,15 @@ export async function launchBrowser({
 				executablePath,
 				ignoreHTTPSErrors: true,
 				acceptDownloads: true,
-				ignoreDefaultArgs: ['--disable-extensions', '--enable-automation', '--no-sandbox'],
-				args: ['--window-position=0,0', '--no-first-run', '--no-default-browser-check', ...args]
+				ignoreDefaultArgs: ['--disable-extensions', '--enable-automation'],
+				args: [
+					'--window-position=0,0',
+					'--no-first-run',
+					'--no-default-browser-check',
+					'--no-sandbox',
+					'--disable-setuid-sandbox',
+					...args
+				]
 			})
 			.then(async (browser) => {
 				// 处理浏览器初始

--- a/packages/common/src/utils/valid.browser.ts
+++ b/packages/common/src/utils/valid.browser.ts
@@ -2,7 +2,7 @@ import { existsSync } from 'fs';
 import { join } from 'path';
 import { ValidBrowser } from '../interface';
 import os from 'os';
-import 'electron';
+import { app } from 'electron';
 
 // 获取可用浏览器路径
 export function getValidBrowsers(): ValidBrowser[] {
@@ -33,6 +33,14 @@ export function getValidBrowsers(): ValidBrowser[] {
 				}
 			].filter((b) => b.path) as ValidBrowser[];
 		}
+		case 'linux': {
+			return [
+				{
+					name: '软件内置浏览器-谷歌(Chrome)',
+					path: resolveBrowserPath('bin/chrome/chrome/chrome')
+				}
+			].filter((b) => b.path) as ValidBrowser[];
+		}
 		default: {
 			return [];
 		}
@@ -41,6 +49,7 @@ export function getValidBrowsers(): ValidBrowser[] {
 
 function resolveBrowserPath(commonPath: string) {
 	return [
+		join(app.getPath('userData'), commonPath),
 		join(process.resourcesPath, commonPath),
 		...(process.platform === 'win32'
 			? [

--- a/packages/web/src/pages/user-scripts/index.vue
+++ b/packages/web/src/pages/user-scripts/index.vue
@@ -1,7 +1,7 @@
 <template>
 	<div class="col-12 p-2 m-auto h-100">
 		<a-tabs
-			v-model:activeKey="state.activeKey"
+			v-model:active-key="state.activeKey"
 			class="overflow-auto h-100"
 		>
 			<a-tab-pane
@@ -266,7 +266,7 @@
 					</div>
 
 					<div class="col-12">
-						<a-tabs v-model:activeKey="state.engineKey">
+						<a-tabs v-model:active-key="state.engineKey">
 							<a-tab-pane
 								v-for="item of engineSearchList"
 								:key="item.engine.name"

--- a/packages/web/src/utils/environment.ts
+++ b/packages/web/src/utils/environment.ts
@@ -84,27 +84,50 @@ export const Environment = {
 			extension.installed = await resourceLoader.isZipFileExists('extensions', extension);
 		}
 		const installed_extension = extensions.find((e) => e.installed);
-		if (!installed_extension) return;
-
-		const manifest = JSON.parse(
-			String(
-				await remote.fs.call(
-					'readFileSync',
-					await remote.path.call(
-						'join',
-						await resourceLoader.getUnzippedPath('extensions', installed_extension),
-						'manifest.json'
-					),
-					'utf-8'
+		if (installed_extension) {
+			const manifest = JSON.parse(
+				String(
+					await remote.fs.call(
+						'readFileSync',
+						await remote.path.call(
+							'join',
+							await resourceLoader.getUnzippedPath('extensions', installed_extension),
+							'manifest.json'
+						),
+						'utf-8'
+					)
 				)
-			)
-		);
-		// 检查是否为 MV2 拓展，如果是则报错
-		if (_get(manifest, 'manifest_version', 2) < 3) {
-			return undefined;
+			);
+			// 检查是否为 MV2 拓展，如果是则报错
+			if (_get(manifest, 'manifest_version', 2) < 3) {
+				return undefined;
+			}
+			return installed_extension;
 		}
 
-		return installed_extension;
+		// 兜底：远程资源列表未命中时，直接扫描本地 extensions 目录
+		try {
+			// @ts-ignore
+			const paths: string[] = await remote.fs.call('readdirSync', store.paths.extensionsFolder);
+			for (const file of paths.filter((f) => f !== '.DS_Store')) {
+				const extensionPath = await remote.path.call('join', store.paths.extensionsFolder, file);
+				const isDirectory = remote.methods.callSync('isDirectory', extensionPath);
+				if (!isDirectory) continue;
+				const manifestPath = await remote.path.call('join', extensionPath, 'manifest.json');
+				const exists = await remote.fs.call('existsSync', manifestPath);
+				if (!exists) continue;
+
+				const manifest = JSON.parse(String(await remote.fs.call('readFileSync', manifestPath, 'utf-8')));
+				if (_get(manifest, 'manifest_version', 2) >= 3) {
+					return {
+						id: file,
+						name: _get(manifest, 'name', file),
+						url: '',
+						installed: true
+					} as Extension;
+				}
+			}
+		} catch {}
 	},
 
 	async getValidUserScript() {


### PR DESCRIPTION
1. **首次初始化后的重启竞态**
   - 首次解压内置浏览器后会触发 `app.relaunch() + app.quit()`；
   - 但启动流程仍继续执行 `window.loadFile('./public/index.html')`；
   - AppImage 的 `/tmp/.mount_*` 挂载路径在该时刻不稳定，导致加载 `file:///tmp/.mount_*/.../index.html` 失败并抛出 `ERR_FAILED`。

2. **Linux 浏览器识别与版本判定链路不完整**
   - Linux 下未纳入内置浏览器候选路径，导致“可用浏览器”列表可能为 0；
   - 主版本号解析在 Linux 场景缺乏兜底，可能返回空值并被误判为“不受支持”。

3. **脚本管理器安装状态过度依赖远程资源映射**
   - 原逻辑优先按远程 `resourceGroups.extensions` 与本地解压目录匹配；
   - 当远程映射未命中本地实际扩展时，会误报“未安装脚本管理器”。

4. **Linux 内置 Chrome 子可执行文件权限缺失**
   - 仅赋权主程序 `chrome` 不足；
   - `chrome_crashpad_handler` 等子可执行文件无执行权限时，会在启动阶段直接崩溃（权限错误 13）。

5. **窗口销毁后的异步回写**
   - 在 `quit/close` 或重启阶段，部分 IPC 回复/消息发送仍尝试访问已销毁的 `webContents`，触发 `Object has been destroyed`。